### PR TITLE
add more gogs settings to default app.ini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV GOGS_POSTGRES_DB_NAME gogs
 ENV GOGS_POSTGRES_USER gogs
 ENV GOGS_POSTGRES_PASSWORD gogs
 ENV GOGS_DOMAIN gogs.test.dashboard.hyperdev.cloud
+ENV GOGS_HTTP_PORT 3000
 
 ADD app.ini $GOGS_CUSTOM/conf/app.ini.orig
 ADD ldap_bind_dn.conf $GOGS_CUSTOM/conf/auth.d/ldap_bind_dn.conf.orig

--- a/README.md
+++ b/README.md
@@ -2,17 +2,23 @@
 GOGS image for Hyperdev.io, configurable via env vars
 
 ## Available env vars
-- GOGS_LDAP_HOST
-- GOGS_LDAP_PORT
-- GOGS_LDAP_BIND_DN
-- GOGS_LDAP_BIND_PASSWORD
-- GOGS_LDAP_USER_BASE
-- GOGS_POSTGRES_HOST
-- GOGS_POSTGRES_PORT
-- GOGS_POSTGRES_DB_NAME
-- GOGS_POSTGRES_USER
-- GOGS_POSTGRES_PASSWORD
-- GOGS_DOMAIN
+For gogs itself:
+- GOGS_DOMAIN `gogs.test.dashboard.hyperdev.cloud`: you should set this to `"${HYPERDEV}"`
+- GOGS_HTTP_PORT `3000`: port gogs will listen on within the container, also used for http git clone url
+
+For gogs' connection to the postgres DB
+- GOGS_POSTGRES_HOST `db`
+- GOGS_POSTGRES_PORT `5432`
+- GOGS_POSTGRES_DB_NAME `gogs`
+- GOGS_POSTGRES_USER `gogs`
+- GOGS_POSTGRES_PASSWORD `gogs`
+
+For gogs' connection to LDAP
+- GOGS_LDAP_HOST: set this to `"ldap.${HYPERDEV_PROJECT}.hyperdev.cloud"`
+- GOGS_LDAP_PORT `389`: you shoudn't need to changes this
+- GOGS_LDAP_BIND_DN: set this to `"cn=readonly,dc=${HYPERDEV_PROJECT},dc=hyperdev,dc=cloud"`
+- GOGS_LDAP_BIND_PASSWORD `"readonly"`: you shouldn't need to change this.
+- GOGS_LDAP_USER_BASE: you should set this to `"dc=${HYPERDEV_PROJECT},dc=hyperdev,dc=cloud"`
 
 ## Volumes that need to be persisted
 - /data

--- a/README.md
+++ b/README.md
@@ -3,22 +3,31 @@ GOGS image for Hyperdev.io, configurable via env vars
 
 ## Available env vars
 For gogs itself:
-- GOGS_DOMAIN `gogs.test.dashboard.hyperdev.cloud`: you should set this to `"${HYPERDEV}"`
-- GOGS_HTTP_PORT `3000`: port gogs will listen on within the container, also used for http git clone url
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| GOGS_DOMAIN | `gogs.test.dashboard.hyperdev.cloud` | you should set this to `"${HYPERDEV_SERVICE_NAME}.${HYPERDEV_INSTANCE_NAME}.${HYPERDEV_PROJECT}.hyperdev.cloud"` |
+| GOGS_HTTP_PORT | `3000` | port gogs will listen on within the container, also used for http git clone url |
 
 For gogs' connection to the postgres DB
-- GOGS_POSTGRES_HOST `db`
-- GOGS_POSTGRES_PORT `5432`
-- GOGS_POSTGRES_DB_NAME `gogs`
-- GOGS_POSTGRES_USER `gogs`
-- GOGS_POSTGRES_PASSWORD `gogs`
+
+| Variable | Default |
+|----------|---------|
+| GOGS_POSTGRES_HOST | `db` |
+| GOGS_POSTGRES_PORT | `5432` |
+| GOGS_POSTGRES_DB_NAME | `gogs` |
+| GOGS_POSTGRES_USER | `gogs` |
+| GOGS_POSTGRES_PASSWORD | `gogs` |
 
 For gogs' connection to LDAP
-- GOGS_LDAP_HOST: set this to `"ldap.${HYPERDEV_PROJECT}.hyperdev.cloud"`
-- GOGS_LDAP_PORT `389`: you shoudn't need to changes this
-- GOGS_LDAP_BIND_DN: set this to `"cn=readonly,dc=${HYPERDEV_PROJECT},dc=hyperdev,dc=cloud"`
-- GOGS_LDAP_BIND_PASSWORD `"readonly"`: you shouldn't need to change this.
-- GOGS_LDAP_USER_BASE: you should set this to `"dc=${HYPERDEV_PROJECT},dc=hyperdev,dc=cloud"`
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| GOGS_LDAP_HOST | None | set this to `"ldap.${HYPERDEV_PROJECT}.hyperdev.cloud"` |
+| GOGS_LDAP_PORT | `389` | you shoudn't need to changes this |
+| GOGS_LDAP_BIND_DN | None | set this to `"cn=readonly,dc=${HYPERDEV_PROJECT},dc=hyperdev,dc=cloud"` |
+| GOGS_LDAP_BIND_PASSWORD | `"readonly"` | you shouldn't need to change this. |
+| GOGS_LDAP_USER_BASE | None | you should set this to `"dc=${HYPERDEV_PROJECT},dc=hyperdev,dc=cloud"` |
 
 ## Volumes that need to be persisted
 - /data

--- a/app.ini
+++ b/app.ini
@@ -1,3 +1,5 @@
+APP_NAME = Gogs
+RUN_USER = git
 RUN_MODE = prod
 
 [database]
@@ -7,9 +9,40 @@ NAME = $GOGS_POSTGRES_DB_NAME
 USER = $GOGS_POSTGRES_USER
 PASSWD = $GOGS_POSTGRES_PASSWORD
 
-[security]
-INSTALL_LOCK = true
+[repository]
+ROOT = /data/git/gogs-repositories
 
 [server]
-LANDING_PAGE = explore
-DOMAIN = $GOGS_DOMAIN
+DOMAIN           = $GOGS_DOMAIN
+HTTP_PORT        = $GOGS_HTTP_PORT
+ROOT_URL         = http://$GOGS_DOMAIN:$GOGS_HTTP_PORT/
+DISABLE_SSH      = false
+SSH_PORT         = 22
+START_SSH_SERVER = false
+OFFLINE_MODE     = false
+LANDING_PAGE     = explore
+
+[mailer]
+ENABLED = false
+
+[service]
+REGISTER_EMAIL_CONFIRM = false
+ENABLE_NOTIFY_MAIL     = false
+DISABLE_REGISTRATION   = false
+ENABLE_CAPTCHA         = true
+REQUIRE_SIGNIN_VIEW    = false
+
+[picture]
+DISABLE_GRAVATAR        = false
+ENABLE_FEDERATED_AVATAR = false
+
+[session]
+PROVIDER = file
+
+[log]
+MODE      = console, file
+LEVEL     = Info
+ROOT_PATH = /app/gogs/log
+
+[security]
+INSTALL_LOCK = true


### PR DESCRIPTION
This adds another environment variable: `GOGS_HTTP_PORT` to the config.

This also adds a lot of settings that gogs has set. 
I copied the app.ini from an instance running in HyperDev, and compared it with the one in this repository.

Please check if I didn't hardcode anything important :-)